### PR TITLE
Fix - Domains list parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "mail"
   ],
   "dependencies": {
-    "cheerio": "~1.0.0-rc.3",
     "got": "~11.8.0",
     "json-future": "~2.2.4"
   },

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,6 +5,8 @@
 const jsonFuture = require('json-future')
 const got = require('got')
 
+/* List of free email domains by HubSpot
+   https://knowledge.hubspot.com/forms/what-domains-are-blocked-when-using-the-forms-email-domains-to-block-feature */
 const fetchList = () =>
   got(
     'https://f.hubspotusercontent40.net/hubfs/2832391/Marketing/Lead-Capture/free-domains-1.csv'

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -11,7 +11,7 @@ const fetchList = () =>
   ).text()
 
 const trim = (text) =>
-  text.replace(/^\s+|\s+$|,$/g, '')
+  text.replace(/^\s+|\s+$/g, '')
 
 const save = async body => {
   const result = body.split(/,/g)

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,29 +3,21 @@
 'use strict'
 
 const jsonFuture = require('json-future')
-const cheerio = require('cheerio')
 const got = require('got')
 
 const fetchList = () =>
   got(
-    'https://knowledge.hubspot.com/articles/kcs_article/forms/what-domains-are-blocked-when-using-the-forms-email-domains-to-block-feature'
+    'https://f.hubspotusercontent40.net/hubfs/2832391/Marketing/Lead-Capture/free-domains-1.csv'
   ).text()
 
-const REGEX_SEPARATOR = new RegExp('<br>', 'g')
+const trim = (text) =>
+  text.replace(/^\s+|\s+$|,$/g, '')
 
 const save = async body => {
-  const $ = cheerio.load(body)
-  let result = []
+  const result = body.split(/,/g)
+    .map(trim)
+    .filter()
 
-  $('span > p').each(function (i, el) {
-    if (i !== 0) {
-      const domains = $(this)
-        .html()
-        .replace(REGEX_SEPARATOR, ' ')
-        .split(' ')
-      result = result.concat(domains)
-    }
-  })
   await jsonFuture.saveAsync('domains.json', result)
 }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -16,7 +16,7 @@ const trim = (text) =>
 const save = async body => {
   const result = body.split(/,/g)
     .map(trim)
-    .filter()
+    .filter(Boolean)
 
   await jsonFuture.saveAsync('domains.json', result)
 }


### PR DESCRIPTION
Fixes #12 

-  Simplify domains parsing by switching to using CSV
   See [the source HubSpot page](https://knowledge.hubspot.com/forms/what-domains-are-blocked-when-using-the-forms-email-domains-to-block-feature): they have linked their source CSV file to it

- Drop unnecessary `cheerio` package dependency