### PR TITLE
Use CommonJS export for "module": "node16"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 import freeEmailDomains from './domains.json' assert { type: 'json' }
-export default freeEmailDomains
+export = freeEmailDomains


### PR DESCRIPTION
Hi @Kikobeats 👋 Hope you're well.

The ESM-style `export default freeEmailDomains` causes errors with `"module": "node16"` configured in `tsconfig.json`:

```bash
$ yarn tsc
index.ts:3:18 - error TS2339: Property 'map' does not exist on type 'typeof import("/home/projects/node-c7qtuh/node_modules/free-email-domains/index")'.

3 freeEmailDomains.map(() => {});
                   ~~~


Found 1 error in index.ts:3

error Command failed with exit code 2.
```

Demo on StackBlitz - run `yarn tsc` in the Terminal at the bottom to reproduce:

https://stackblitz.com/edit/node-c7qtuh?file=tsconfig.json,package.json,index.ts

![Screenshot 2023-01-29 at 19 11 01](https://user-images.githubusercontent.com/1935696/215347329-f52c4f52-5a55-407e-9354-afb976dd5f89.png)

## Proposed Solution

Switching `export default freeEmailDomains` to `export = freeEmailDomains` causes this problem to go away.

cc @andrewbranch another PR to declaration files for `"module": "node16"`, happy to change this one too in case there's a better solution than `export =`