### PR TITLE
feat: add free email domains not blocked by HubSpot to validation list

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -14,9 +14,9 @@ const URL =
   'https://f.hubspotusercontent40.net/hubfs/2832391/Marketing/Lead-Capture/free-domains-2.csv'
 
 /** Additional domains not present in the URL */
-const DOMAINS = ['pm.me', 'proton.me', 'protonmail.ch','yopmail.com','sharklasers.com','guerrillamail.com','mailinator.com','10minutemail.com','spambox.xyz',
-  'throwawaymail.com','emailondeck.com','maildrop.cc','temp-mail.org','tempmail.com','tempmail.net','tmails.net','mail.tm','mohmal.com','mail4trash.com','2mik.com',
-  '3dboxer.com','hosliy.com','forcrack.com']
+const DOMAINS = ['pm.me', 'proton.me', 'protonmail.ch','sharklasers.com','guerrillamail.com','10minutemail.com','spambox.xyz',
+ 'throwawaymail.com','emailondeck.com','temp-mail.org','tempmail.com','tempmail.net','tmails.net',
+ 'mail.tm','2mik.com','3dboxer.com','hosliy.com','forcrack.com']
 
 const trim = text => text.replace(/^\s+|\s+$/g, '')
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -14,7 +14,9 @@ const URL =
   'https://f.hubspotusercontent40.net/hubfs/2832391/Marketing/Lead-Capture/free-domains-2.csv'
 
 /** Additional domains not present in the URL */
-const DOMAINS = ['pm.me', 'proton.me', 'protonmail.ch']
+const DOMAINS = ['pm.me', 'proton.me', 'protonmail.ch','yopmail.com','sharklasers.com','guerrillamail.com','mailinator.com','10minutemail.com','spambox.xyz',
+  'throwawaymail.com','emailondeck.com','maildrop.cc','temp-mail.org','tempmail.com','tempmail.net','tmails.net','mail.tm','mohmal.com','mail4trash.com','2mik.com',
+  '3dboxer.com','hosliy.com','forcrack.com']
 
 const trim = text => text.replace(/^\s+|\s+$/g, '')
 


### PR DESCRIPTION
### ✅ Summary

This PR adds a curated list of disposable and free email domains **not currently blocked by HubSpot's built-in “Block free email” feature**. These domains are frequently used for spam, testing, or bypassing form restrictions, and should be explicitly blocked for better email hygiene and data quality.

---

### 📥 Domains Added

| Domain               | Service            |
|----------------------|--------------------|
| sharklasers.com      | Guerrilla Mail     |
| guerrillamail.com    | Guerrilla Mail     |
| 10minutemail.com     | 10 Minute Mail     |
| spambox.xyz          | Spambox            |
| throwawaymail.com    | ThrowAwayMail      |
| emailondeck.com      | EmailOnDeck        |
| temp-mail.org        | Temp-Mail          |
| tempmail.com         | Temp-Mail          |
| tempmail.net         | Temp-Mail          |
| tmails.net           | Tmails             |
| mail.tm              | Mail.tm            |
| 2mik.com             | Misc (list repo)   |
| 3dboxer.com          | Misc (list repo)   |
| hosliy.com           | Misc (list repo)   |
| forcrack.com         | Misc (list repo)   |

> **Note**: Sources for all domains are included in the linked CSV.

---

### 🧾 Why This Matters

- 🧹 Improves **lead data quality**
- 🧪 Reduces **test spam and junk registrations**
- 🛡️ Enhances protection from temporary/disposable sign-ups
- ❌ These are **not covered by HubSpot's default block list**


### 📚 Sources

- [Guerrilla Mail](https://www.guerrillamail.com/)
- [Temp-Mail](https://temp-mail.org/)
- [ThrowAwayMail](https://www.throwawaymail.com/)
- [GitHub: disposable-email-domains](https://github.com/disposable/disposable-email-domains)

