### PR TITLE
Remove poetic.com

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -9522,7 +9522,6 @@
   "poczta.fm",
   "poczta.onet.pl",
   "poehali-otdihat.ru",
-  "poetic.com",
   "pofmagic.com",
   "pojok.ml",
   "pokemail.net",


### PR DESCRIPTION
poetic.com has now been moved to a private Google Workspace and is no longer a public free email domain.

- Mail.com no longer lists poetic.com among its available free-email domains like it used to: https://www.mail.com/mail/domains/
- The domain now has an MX record pointing to smtp.google.com, indicating that the domain’s email is hosted by a Google Workspace organization.