### PR TITLE
feat: add AOL country domains and 1&1/IONOS consumer mail domains

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -18,6 +18,9 @@ const SOURCES = [
 /** Additional domains not present in the URL */
 const DOMAINS = [
   '2iij.net',
+  'aol.co.uk',
+  'aol.de',
+  'aol.fr',
   'asahi-net.or.jp',
   'au.com',
   'auone-net.jp',
@@ -34,6 +37,7 @@ const DOMAINS = [
   'docomo.ne.jp',
   'dreamwiz.com',
   'dti.ne.jp',
+  'e-mail.de',
   'emnet.ne.jp',
   'emobile.ne.jp',
   'eonet.ne.jp',
@@ -71,6 +75,9 @@ const DOMAINS = [
   'ocn.ne.jp',
   'odn.ad.jp',
   'odn.ne.jp',
+  'online-home.de',
+  'online.de',
+  'onlinehome.de',
   'panda.tnc.ne.jp',
   'paran.com',
   'pdx.ne.jp',


### PR DESCRIPTION
### What

Adds seven consumer mailbox domains to the `DOMAINS` extras list in `scripts/postinstall.mjs`:

- `aol.co.uk`, `aol.de`, `aol.fr`
- `online.de`, `onlinehome.de`, `online-home.de`, `e-mail.de`

### Why

Each one belongs to a provider the list **already covers under a different domain**:

| added | provider | already on the list |
|---|---|---|
| `aol.co.uk`, `aol.de`, `aol.fr` | AOL Mail | `aol.com` |
| `online.de`, `onlinehome.de` | 1&1 (United Internet) | `gmx.de`, `web.de`, `online.nl` |
| `online-home.de`, `e-mail.de` | IONOS (United Internet) | `gmx.de`, `web.de` |

GMX and WEB.DE are United Internet brands and are covered; the 1&1 / IONOS consumer mailboxes from the same parent company are not. `online.nl` is present while `online.de` is not.

### Evidence

All seven resolve to the mail infrastructure of a provider already on the list — the AOL country domains share an MX host with `aol.com` exactly:

```
$ dig +short MX aol.com aol.de aol.co.uk aol.fr
10 mx-aol.mail.gm0.yahoodns.net.
15 mx-aol.mail.gm0.yahoodns.net.
15 mx-aol.mail.gm0.yahoodns.net.
15 mx-aol.mail.gm0.yahoodns.net.

$ dig +short MX online.de onlinehome.de
10 mx00.emig.kundenserver.de.     # 1&1
10 mx00.emig.kundenserver.de.

$ dig +short MX online-home.de e-mail.de
10 mx00.ionos.de.                 # IONOS
10 mx00.ionos.de.
```

1&1 hands these out as free mailboxes with its consumer internet access ([1&1 FreeMail](https://home.1und1.de/)), which is the same category as the `t-online.de` and `freenet.de` entries the list already carries.

### Context

We hit this in production: signups on `@online.de` were being classified as business addresses.

Edited `scripts/postinstall.mjs` rather than `domains.json`, since the latter is regenerated from the upstream sources on install. Entries are inserted in the existing sort order; no other lines are touched.
